### PR TITLE
RFC: improved error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,6 @@
+instrumentation:
+  include-all-sources: true
+reporting:
+  print: detail
+  reports:
+    - html

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function (src, dest, opts, cb) {
 					cb();
 					return;
 				}
-				cb(new CpFileError(err, 'cannot write to `' + dest + '`: ' + err.message, err));
+				cb(new CpFileError('cannot write to `' + dest + '`: ' + err.message, err));
 			});
 
 			write.on('close', function () {
@@ -136,8 +136,18 @@ module.exports.sync = function (src, dest, opts) {
 		pos += bytesRead;
 	}
 
-	stat = fs.fstatSync(read);
-	fs.futimesSync(write, stat.atime, stat.mtime);
+	try {
+		stat = fs.fstatSync(read);
+	} catch (err) {
+		throw new CpFileError('stat `' + src + '` failed: ' + err.message, err);
+	}
+
+	try {
+		fs.futimesSync(write, stat.atime, stat.mtime);
+	} catch (err) {
+		throw new CpFileError('utimes `' + dest + '` failed: ' + err.message, err);
+	}
+
 	fs.closeSync(read);
 	fs.closeSync(write);
 };

--- a/index.js
+++ b/index.js
@@ -33,11 +33,7 @@ module.exports = function (src, dest, opts, cb) {
 	var readListener = onetime(startWrite);
 
 	read.on('error', function (err) {
-		if (err) {
-			err = new CpFileError('cannot read from `' + src + '`: ' + err.message, err);
-		}
-
-		cb(err);
+		cb(new CpFileError('cannot read from `' + src + '`: ' + err.message, err));
 	});
 	read.on('readable', readListener);
 	read.on('end', readListener);
@@ -68,9 +64,10 @@ module.exports = function (src, dest, opts, cb) {
 
 					fs.utimes(dest, stats.atime, stats.mtime, function (err) {
 						if (err) {
-							err = new CpFileError('utimes `' + dest + '` failed: ' + err.message, err);
+							cb(new CpFileError('utimes `' + dest + '` failed: ' + err.message, err));
+							return;
 						}
-						cb(err);
+						cb();
 					});
 				});
 			});

--- a/index.js
+++ b/index.js
@@ -84,12 +84,9 @@ module.exports.sync = function (src, dest, opts) {
 
 	opts = objectAssign({overwrite: true}, opts);
 
-	var read = fs.openSync(src, 'r');
 	var BUF_LENGTH = 100 * 1024;
 	var buf = new Buffer(BUF_LENGTH);
-	var bytesRead = readSync(0);
-	var pos = bytesRead;
-	var write;
+	var read, bytesRead, pos, write, stat;
 
 	function readSync(pos) {
 		try {
@@ -106,6 +103,14 @@ module.exports.sync = function (src, dest, opts) {
 			throw new CpFileError('cannot write to `' + dest + '`: ' + err.message, err);
 		}
 	}
+
+	try {
+		read = fs.openSync(src, 'r');
+	} catch (err) {
+		throw new CpFileError('cannot open `' + src + '`: ' + err.message, err);
+	}
+
+	pos = bytesRead = readSync(0);
 
 	try {
 		mkdirp.sync(path.dirname(dest));
@@ -131,7 +136,7 @@ module.exports.sync = function (src, dest, opts) {
 		pos += bytesRead;
 	}
 
-	var stat = fs.fstatSync(read);
+	stat = fs.fstatSync(read);
 	fs.futimesSync(write, stat.atime, stat.mtime);
 	fs.closeSync(read);
 	fs.closeSync(write);

--- a/index.js
+++ b/index.js
@@ -4,13 +4,21 @@ var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
 var objectAssign = require('object-assign');
 var onetime = require('onetime');
-var VError = require('verror');
+var NestedError = require('nested-error-stacks');
+var util = require('util');
+
+function CpFileError(message, nested) {
+	NestedError.call(this, message, nested);
+	objectAssign(this, nested, {message: message});
+}
+
+util.inherits(CpFileError, NestedError);
+
+CpFileError.prototype.name = 'CpFileError';
 
 module.exports = function (src, dest, opts, cb) {
 	if (!src || !dest) {
-		var err = new VError('`src` and `dest` required');
-		err.name = 'CpFileError';
-		throw err;
+		throw new CpFileError('`src` and `dest` required');
 	}
 
 	if (typeof opts !== 'object') {
@@ -26,8 +34,7 @@ module.exports = function (src, dest, opts, cb) {
 
 	read.on('error', function (err) {
 		if (err) {
-			err = new VError(err, 'cannot read from `' + src + '`');
-			err.name = 'CpFileError';
+			err = new CpFileError('cannot read from `' + src + '`: ' + err.message, err);
 		}
 
 		cb(err);
@@ -38,9 +45,7 @@ module.exports = function (src, dest, opts, cb) {
 	function startWrite() {
 		mkdirp(path.dirname(dest), function (err) {
 			if (err && err.code !== 'EEXIST') {
-				err = new VError(err, 'cannot create directory `' + path.dirname(dest) + '`');
-				err.name = 'CpFileError';
-				cb(err);
+				cb(new CpFileError('cannot create directory `' + path.dirname(dest) + '`: ' + err.message, err));
 				return;
 			}
 
@@ -51,24 +56,19 @@ module.exports = function (src, dest, opts, cb) {
 					cb();
 					return;
 				}
-				err = new VError(err, 'cannot write to `' + dest + '`');
-				err.name = 'CpFileError';
-				cb(err);
+				cb(new CpFileError(err, 'cannot write to `' + dest + '`: ' + err.message, err));
 			});
 
 			write.on('close', function () {
 				fs.lstat(src, function (err, stats) {
 					if (err) {
-						err = new VError(err, 'lstat `' + src + '` failed');
-						err.name = 'CpFileError';
-						cb(err);
+						cb(new CpFileError('lstat `' + src + '` failed: ' + err.message, err));
 						return;
 					}
 
 					fs.utimes(dest, stats.atime, stats.mtime, function (err) {
 						if (err) {
-							err = new VError(err, 'utimes `' + dest + '` failed');
-							err.name = 'CpFileError';
+							err = new CpFileError('utimes `' + dest + '` failed: ' + err.message, err);
 						}
 						cb(err);
 					});
@@ -80,12 +80,9 @@ module.exports = function (src, dest, opts, cb) {
 	}
 };
 
-
 module.exports.sync = function (src, dest, opts) {
 	if (!src || !dest) {
-		var err = new VError('`src` and `dest` required');
-		err.name = 'CpFileError';
-		throw err;
+		throw new CpFileError('`src` and `dest` required');
 	}
 
 	opts = objectAssign({overwrite: true}, opts);
@@ -101,9 +98,7 @@ module.exports.sync = function (src, dest, opts) {
 		try {
 			return fs.readSync(read, buf, 0, BUF_LENGTH, pos);
 		} catch (err) {
-			err = new VError(err, 'cannot read from `' + src + '`');
-			err.name = 'CpFileError';
-			throw err;
+			throw new CpFileError('cannot read from `' + src + '`: ' + err.message, err);
 		}
 	}
 
@@ -111,9 +106,7 @@ module.exports.sync = function (src, dest, opts) {
 		try {
 			fs.writeSync(write, buf, 0, bytesRead);
 		} catch (err) {
-			err = new VError(err, 'cannot write to `' + dest + '`');
-			err.name = 'CpFileError';
-			throw err;
+			throw new CpFileError('cannot write to `' + dest + '`: ' + err.message, err);
 		}
 	}
 
@@ -121,9 +114,7 @@ module.exports.sync = function (src, dest, opts) {
 		mkdirp.sync(path.dirname(dest));
 	} catch (err) {
 		if (err.code !== 'EEXIST') {
-			err = new VError(err, 'cannot create directory `' + path.dirname(dest) + '`');
-			err.name = 'CpFileError';
-			throw err;
+			throw new CpFileError('cannot create directory `' + path.dirname(dest) + '`: ' + err.message, err);
 		}
 	}
 
@@ -133,9 +124,7 @@ module.exports.sync = function (src, dest, opts) {
 		if (!opts.overwrite && err.code === 'EEXIST') {
 			return;
 		}
-		err = new VError(err, 'cannot write to `' + dest + '`');
-		err.name = 'CpFileError';
-		throw err;
+		throw new CpFileError('cannot write to `' + dest + '`: ' + err.message, err);
 	}
 
 	writeSync();

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var util = require('util');
 
 function CpFileError(message, nested) {
 	NestedError.call(this, message, nested);
-	objectAssign(this, nested, {message: message});
+	objectAssign(this, nested);
 }
 
 util.inherits(CpFileError, NestedError);

--- a/index.js
+++ b/index.js
@@ -2,13 +2,15 @@
 var path = require('path');
 var fs = require('graceful-fs');
 var mkdirp = require('mkdirp');
-var assign = require('object-assign');
+var objectAssign = require('object-assign');
 var onetime = require('onetime');
 var VError = require('verror');
 
 module.exports = function (src, dest, opts, cb) {
 	if (!src || !dest) {
-		throw new assign(new VError('`src` and `dest` required'), { name: 'CpFileError' })
+		var err = new VError('`src` and `dest` required');
+		err.name = 'CpFileError';
+		throw err;
 	}
 
 	if (typeof opts !== 'object') {
@@ -17,14 +19,15 @@ module.exports = function (src, dest, opts, cb) {
 	}
 
 	cb = onetime(cb || function () {});
-	opts = assign({overwrite: true}, opts);
+	opts = objectAssign({overwrite: true}, opts);
 
 	var read = fs.createReadStream(src);
 	var readListener = onetime(startWrite);
 
 	read.on('error', function (err) {
 		if (err) {
-			err = assign(new VError(err, 'cannot read from \'%s\'', src), { name: 'CpFileError' });
+			err = new VError(err, 'cannot read from `' + src + '`');
+			err.name = 'CpFileError';
 		}
 
 		cb(err);
@@ -35,7 +38,9 @@ module.exports = function (src, dest, opts, cb) {
 	function startWrite() {
 		mkdirp(path.dirname(dest), function (err) {
 			if (err && err.code !== 'EEXIST') {
-				cb(assign(new VError(err, 'cannot create directory \'%s\'', dest), { name: 'CpFileError' }));
+				err = new VError(err, 'cannot create directory `' + path.dirname(dest) + '`');
+				err.name = 'CpFileError';
+				cb(err);
 				return;
 			}
 
@@ -46,20 +51,24 @@ module.exports = function (src, dest, opts, cb) {
 					cb();
 					return;
 				}
-
-				cb(assign(new VError(err, 'cannot write to \'%s\'', dest), { name: 'CpFileError' }));
+				err = new VError(err, 'cannot write to `' + dest + '`');
+				err.name = 'CpFileError';
+				cb(err);
 			});
 
 			write.on('close', function () {
 				fs.lstat(src, function (err, stats) {
 					if (err) {
-						cb(assign(new VError(err, 'lstat \'%s\' failed', src), { name: 'CpFileError' }));
+						err = new VError(err, 'lstat `' + src + '` failed');
+						err.name = 'CpFileError';
+						cb(err);
 						return;
 					}
 
 					fs.utimes(dest, stats.atime, stats.mtime, function (err) {
 						if (err) {
-							err = assign(new VError(err, 'utimes \'%s\' failed', dest), { name: 'CpFileError' });
+							err = new VError(err, 'utimes `' + dest + '` failed');
+							err.name = 'CpFileError';
 						}
 						cb(err);
 					});
@@ -74,10 +83,12 @@ module.exports = function (src, dest, opts, cb) {
 
 module.exports.sync = function (src, dest, opts) {
 	if (!src || !dest) {
-		throw new assign(new VError('`src` and `dest` required'), { name: 'CpFileError' })
+		var err = new VError('`src` and `dest` required');
+		err.name = 'CpFileError';
+		throw err;
 	}
 
-	opts = assign({overwrite: true}, opts);
+	opts = objectAssign({overwrite: true}, opts);
 
 	var read = fs.openSync(src, 'r');
 	var BUF_LENGTH = 100 * 1024;
@@ -90,7 +101,9 @@ module.exports.sync = function (src, dest, opts) {
 		try {
 			return fs.readSync(read, buf, 0, BUF_LENGTH, pos);
 		} catch (err) {
-			throw assign(new VError(err, 'cannot read from \'%s\'', src), { name: 'CpFileError' });
+			err = new VError(err, 'cannot read from `' + src + '`');
+			err.name = 'CpFileError';
+			throw err;
 		}
 	}
 
@@ -98,7 +111,9 @@ module.exports.sync = function (src, dest, opts) {
 		try {
 			fs.writeSync(write, buf, 0, bytesRead);
 		} catch (err) {
-			throw assign(new VError(err, 'cannot write to \'%s\'', dest), { name: 'CpFileError' });
+			err = new VError(err, 'cannot write to `' + dest + '`');
+			err.name = 'CpFileError';
+			throw err;
 		}
 	}
 
@@ -106,7 +121,9 @@ module.exports.sync = function (src, dest, opts) {
 		mkdirp.sync(path.dirname(dest));
 	} catch (err) {
 		if (err.code !== 'EEXIST') {
-			throw assign(new VError(err, 'cannot create directory \'%s\'', dest), { name: 'CpFileError' });
+			err = new VError(err, 'cannot create directory `' + path.dirname(dest) + '`');
+			err.name = 'CpFileError';
+			throw err;
 		}
 	}
 
@@ -116,7 +133,9 @@ module.exports.sync = function (src, dest, opts) {
 		if (!opts.overwrite && err.code === 'EEXIST') {
 			return;
 		}
-		throw assign(new VError(err, 'cannot write to \'%s\'', dest), { name: 'CpFileError' });
+		err = new VError(err, 'cannot write to `' + dest + '`');
+		err.name = 'CpFileError';
+		throw err;
 	}
 
 	writeSync();

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "dependencies": {
     "graceful-fs": "^3.0.2",
     "mkdirp": "^0.5.0",
+    "nested-error-stacks": "0.0.4",
     "object-assign": "^2.0.0",
-    "onetime": "^1.0.0",
-    "verror": "^1.6.0"
+    "onetime": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "buffer-compare": "0.0.1",
     "istanbul": "^0.3.13",
     "mocha": "*",
+    "rewire": "^2.3.1",
     "rimraf": "^2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "onetime": "^1.0.0"
   },
   "devDependencies": {
+    "buffer-compare": "0.0.1",
     "istanbul": "^0.3.13",
     "mocha": "*",
     "rimraf": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "cover": "istanbul cover -x test.js node_modules/mocha/bin/_mocha"
   },
   "files": [
     "index.js"
@@ -34,6 +35,7 @@
     "onetime": "^1.0.0"
   },
   "devDependencies": {
+    "istanbul": "^0.3.13",
     "mocha": "*",
     "rimraf": "^2.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "graceful-fs": "^3.0.2",
     "mkdirp": "^0.5.0",
-    "nested-error-stacks": "0.0.4",
+    "nested-error-stacks": "1.0.0",
     "object-assign": "^2.0.0",
     "onetime": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "graceful-fs": "^3.0.2",
     "mkdirp": "^0.5.0",
     "object-assign": "^2.0.0",
-    "onetime": "^1.0.0"
+    "onetime": "^1.0.0",
+    "verror": "^1.6.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test.js
+++ b/test.js
@@ -93,7 +93,7 @@ describe('cpFile()', function () {
 
 	it('should not create dest on unreadable src', function (cb) {
 		cpFile('node_modules', 'tmp', function (err) {
-			assert(err.code === 'EISDIR');
+			assert(err.cause().code === 'EISDIR');
 			assert.throws(fs.statSync.bind(fs, 'tmp'), /ENOENT/);
 			cb();
 		});

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var rimraf = require('rimraf');
 var crypto = require('crypto');
 var bufferCompare = Buffer.compare || require('buffer-compare');
 var rewire = require('rewire');
+var objectAssign = require('object-assign');
 
 /**
  * Tests equality of Date objects, w/o considering milliseconds.
@@ -215,8 +216,7 @@ describe('cpFile()', function () {
 		noSpaceError.errno = -28;
 		noSpaceError.code = 'ENOSPC';
 
-		sut.__set__('fs', {
-			createReadStream: fs.createReadStream,
+		sut.__set__('fs', objectAssign({}, fs, {
 			createWriteStream: function (path, options) {
 				var stream = fs.createWriteStream(path, options);
 				stream.on('pipe', function () {
@@ -227,9 +227,7 @@ describe('cpFile()', function () {
 				});
 				return stream;
 			},
-			lstat: fs.lstat,
-			utimes: fs.utimes,
-		});
+		}));
 
 		sut('license', 'tmp', function (err) {
 			assert.ok(err);
@@ -245,15 +243,13 @@ describe('cpFile()', function () {
 		var sut = rewire('./');
 		var called = 0;
 
-		sut.__set__('fs', {
+		sut.__set__('fs', objectAssign({}, fs, {
 			lstat: function (path, done) {
 				called++;
 				// throw Error:
 				fs.lstat(crypto.randomBytes(64).toString('hex'), done);
 			},
-			createReadStream: fs.createReadStream,
-			createWriteStream: fs.createWriteStream,
-		});
+		}));
 
 		sut('license', 'tmp', function (err) {
 			assert.ok(err);
@@ -268,16 +264,13 @@ describe('cpFile()', function () {
 		var sut = rewire('./');
 		var called = 0;
 
-		sut.__set__('fs', {
+		sut.__set__('fs', objectAssign({}, fs, {
 			utimes: function (path, atime, mtime, done) {
 				called++;
 				// throw Error:
 				fs.utimes(crypto.randomBytes(64).toString('hex'), atime, mtime, done);
 			},
-			lstat: fs.lstat,
-			createReadStream: fs.createReadStream,
-			createWriteStream: fs.createWriteStream,
-		});
+		}));
 
 		sut('license', 'tmp', function (err) {
 			assert.ok(err);
@@ -445,18 +438,13 @@ describe('cpFile.sync()', function () {
 		noSpaceError.errno = -28;
 		noSpaceError.code = 'ENOSPC';
 
-		sut.__set__('fs', {
+		sut.__set__('fs', objectAssign({}, fs, {
 			writeSync: function (fd, buffer, offset, length) {
 				called++;
 				// throw Error:
 				throw noSpaceError;
 			},
-			fstatSync: fs.fstatSync,
-			readSync: fs.readSync,
-			openSync: fs.openSync,
-			futimesSync: fs.futimesSync,
-			closeSync: fs.closeSync,
-		});
+		}));
 
 		try {
 			sut.sync('license', 'tmp');
@@ -479,7 +467,7 @@ describe('cpFile.sync()', function () {
 		openError.code = 'EACCES';
 		openError.path = dirPath,
 
-		sut.__set__('fs', {
+		sut.__set__('fs', objectAssign({}, fs, {
 			openSync: function (path, flags, mode) {
 				if (path === 'tmp') {
 					called++;
@@ -489,12 +477,7 @@ describe('cpFile.sync()', function () {
 					return fs.openSync(path, flags, mode);
 				}
 			},
-			fstatSync: fs.fstatSync,
-			readSync: fs.readSync,
-			writeSync: fs.writeSync,
-			futimesSync: fs.futimesSync,
-			closeSync: fs.closeSync,
-		});
+		}));
 
 		try {
 			sut.sync('license', 'tmp');
@@ -512,16 +495,13 @@ describe('cpFile.sync()', function () {
 		var sut = rewire('./');
 		var called = 0;
 
-		sut.__set__('fs', {
+		sut.__set__('fs', objectAssign({}, fs, {
 			fstatSync: function () {
 				called++;
 				// throw Error:
 				return fs.statSync(crypto.randomBytes(64).toString('hex'));
 			},
-			openSync: fs.openSync,
-			readSync: fs.readSync,
-			writeSync: fs.writeSync,
-		});
+		}));
 
 		try {
 			sut.sync('license', 'tmp');
@@ -537,17 +517,13 @@ describe('cpFile.sync()', function () {
 		var sut = rewire('./');
 		var called = 0;
 
-		sut.__set__('fs', {
+		sut.__set__('fs', objectAssign({}, fs, {
 			futimesSync: function (path, atime, mtime) {
 				called++;
 				// throw Error:
 				return fs.utimesSync(crypto.randomBytes(64).toString('hex'), atime, mtime);
 			},
-			fstatSync: fs.fstatSync,
-			openSync: fs.openSync,
-			readSync: fs.readSync,
-			writeSync: fs.writeSync,
-		});
+		}));
 
 		try {
 			sut.sync('license', 'tmp');

--- a/test.js
+++ b/test.js
@@ -93,7 +93,7 @@ describe('cpFile()', function () {
 
 	it('should not create dest on unreadable src', function (cb) {
 		cpFile('node_modules', 'tmp', function (err) {
-			assert(err.cause().code === 'EISDIR');
+			assert(err.code === 'EISDIR');
 			assert.throws(fs.statSync.bind(fs, 'tmp'), /ENOENT/);
 			cb();
 		});

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@ var assert = require('assert');
 var fs = require('fs');
 var cpFile = require('./');
 var rimraf = require('rimraf');
+var crypto = require('crypto');
+var bufferCompare = Buffer.compare || require('buffer-compare');
 
 /**
  * Tests equality of Date objects, w/o considering milliseconds.
@@ -20,6 +22,7 @@ function assertDateEqual(actual, expected, message) {
 
 function clean() {
 	[
+		'bigFile',
 		'tmp',
 		'EMPTY',
 		'subdir',
@@ -38,6 +41,14 @@ after(function () {
 
 describe('cpFile()', function () {
 
+	it('should throw an Error on missing `src`', function() {
+		assert.throws(cpFile.bind(cpFile), /`src`/);
+	});
+
+	it('should throw an Error on missing `dest`', function() {
+		assert.throws(cpFile.bind(cpFile, 'TARGET'), /`dest`/);
+	});
+
 	it('should copy a file', function (cb) {
 		cpFile('license', 'tmp', function (err) {
 			assert(!err, err);
@@ -55,8 +66,20 @@ describe('cpFile()', function () {
 		});
 	});
 
+	it('should copy big files', function (cb) {
+		var buf = crypto.pseudoRandomBytes(100 * 1024 * 3 + 1);
+
+		fs.writeFileSync('bigFile', buf);
+		cpFile('bigFile', 'tmp', function (err) {
+			assert(!err, err);
+			assert.strictEqual(bufferCompare(buf, fs.readFileSync('tmp')), 0);
+			cb();
+		});
+	});
+
 	it('should not alter overwrite option', function (cb) {
 		var opts = {};
+
 		cpFile('license', 'tmp', opts, function (err) {
 			assert(!err, err);
 			assert.strictEqual(opts.overwrite, undefined);
@@ -93,7 +116,9 @@ describe('cpFile()', function () {
 
 	it('should not create dest on unreadable src', function (cb) {
 		cpFile('node_modules', 'tmp', function (err) {
-			assert(err.code === 'EISDIR');
+			assert(err);
+			assert.strictEqual(err.name, 'CpFileError', 'wrong Error name: ' + err.stack);
+			assert.strictEqual(err.code, 'EISDIR');
 			assert.throws(fs.statSync.bind(fs, 'tmp'), /ENOENT/);
 			cb();
 		});
@@ -102,6 +127,8 @@ describe('cpFile()', function () {
 	it('should not create dest directory on unreadable src', function (cb) {
 		cpFile('node_modules', 'subdir/tmp', function (err) {
 			assert(err);
+			assert.strictEqual(err.name, 'CpFileError', 'wrong Error name: ' + err.stack);
+			assert.strictEqual(err.code, 'EISDIR');
 			assert.throws(fs.statSync.bind(fs, 'subdir'), /ENOENT/);
 			cb();
 		});
@@ -110,16 +137,37 @@ describe('cpFile()', function () {
 	it('should preserve timestamps', function (cb) {
 		cpFile('license', 'tmp', function (err) {
 			assert(!err, err);
+
 			var licenseStats = fs.lstatSync('license');
 			var tmpStats = fs.lstatSync('tmp');
+
 			assertDateEqual(licenseStats.atime, tmpStats.atime);
 			assertDateEqual(licenseStats.mtime, tmpStats.mtime);
+			cb();
+		});
+	});
+
+	it('should throw an Error if `src` does not exists', function (cb) {
+		cpFile('NO_ENTRY', 'tmp', function (err) {
+			assert(err);
+			assert.strictEqual(err.name, 'CpFileError', 'wrong Error name: ' + err.stack);
+			assert.strictEqual(err.code, 'ENOENT');
+			assert.strictEqual(/`NO_ENTRY`/.test(err.message), true, 'Error message does not contain path: ' + err.message);
+			assert.strictEqual(/`NO_ENTRY`/.test(err.stack), true, 'Error stack does not contain path: ' + err.stack);
 			cb();
 		});
 	});
 });
 
 describe('cpFile.sync()', function () {
+	it('should throw an Error on missing `src`', function() {
+		assert.throws(cpFile.sync.bind(cpFile), /`src`/);
+	});
+
+	it('should throw an Error on missing `dest`', function() {
+		assert.throws(cpFile.sync.bind(cpFile, 'TARGET'), /`dest`/);
+	});
+
 	it('should copy a file', function () {
 		cpFile.sync('license', 'tmp');
 		assert.strictEqual(fs.readFileSync('tmp', 'utf8'), fs.readFileSync('license', 'utf8'));
@@ -131,8 +179,17 @@ describe('cpFile.sync()', function () {
 		assert.strictEqual(fs.readFileSync('tmp', 'utf8'), '');
 	});
 
+	it('should copy big files', function () {
+		var buf = crypto.pseudoRandomBytes(100 * 1024 * 3 + 1);
+
+		fs.writeFileSync('bigFile', buf);
+		cpFile.sync('bigFile', 'tmp');
+		assert.strictEqual(bufferCompare(buf, fs.readFileSync('tmp')), 0);
+	});
+
 	it('should not alter overwrite option', function () {
 		var opts = {};
+
 		cpFile.sync('license', 'tmp', opts);
 		assert.strictEqual(opts.overwrite, undefined);
 	});
@@ -156,20 +213,46 @@ describe('cpFile.sync()', function () {
 	});
 
 	it('should not create dest on unreadable src', function () {
-		assert.throws(cpFile.sync.bind(cpFile, 'node_modules', 'tmp'), /EISDIR/);
-		assert.throws(fs.statSync.bind(fs, 'tmp'), /ENOENT/);
+		try {
+			cpFile.sync('node_modules', 'tmp');
+			assert.fail(undefined, Error, 'Missing expected exception');
+		} catch (err) {
+			assert.strictEqual(err.name, 'CpFileError', 'wrong Error name: ' + err.stack);
+			assert.strictEqual(err.code, 'EISDIR');
+			assert.throws(fs.statSync.bind(fs, 'tmp'), /ENOENT/);
+		}
 	});
 
 	it('should not create dest directory on unreadable src', function () {
-		assert.throws(cpFile.sync.bind(cpFile, 'node_modules', 'subdir/tmp'));
-		assert.throws(fs.statSync.bind(fs, 'subdir'), /ENOENT/);
+		try {
+			cpFile.sync('node_modules', 'subdir/tmp');
+			assert.fail(undefined, Error, 'Missing expected exception');
+		} catch (err) {
+			assert.strictEqual(err.name, 'CpFileError', 'wrong Error name: ' + err.stack);
+			assert.strictEqual(err.code, 'EISDIR');
+			assert.throws(fs.statSync.bind(fs, 'subdir'), /ENOENT/);
+		}
 	});
 
 	it('should preserve timestamps', function () {
 		cpFile.sync('license', 'tmp');
+
 		var licenseStats = fs.lstatSync('license');
 		var tmpStats = fs.lstatSync('tmp');
+
 		assertDateEqual(licenseStats.atime, tmpStats.atime);
 		assertDateEqual(licenseStats.mtime, tmpStats.mtime);
+	});
+
+	it('should throw an Error if `src` does not exists', function () {
+		try {
+			cpFile.sync('NO_ENTRY', 'tmp');
+			assert.fail(undefined, Error, 'Missing expected exception');
+		} catch (err) {
+			assert.strictEqual(err.name, 'CpFileError', 'wrong Error name: ' + err.stack);
+			assert.strictEqual(err.code, 'ENOENT');
+			assert.strictEqual(/`NO_ENTRY`/.test(err.message), true, 'Error message does not contain path: ' + err.message);
+			assert.strictEqual(/`NO_ENTRY`/.test(err.stack), true, 'Error stack does not contain path: ' + err.stack);
+		}
 	});
 });


### PR DESCRIPTION
This is an attempt to provide better error messages, but w/o the `err.noStack` workaround (introduced in cpy with https://github.com/sindresorhus/cpy/pull/7).

I've found [Error Handling in Node.js](https://www.joyent.com/developers/node/design/errors) on joyent.com, which partitially relates to this issue. Some suggestions, they make:

> Specific recommendations for writing new functions
> …
> 3. Use the Error's name property to distinguish errors programmatically.
> …
> 5. If you pass a lower-level error to your caller, consider wrapping it instead.
> … At Joyent, we use the [verror](https://github.com/davepacheco/node-verror) module to wrap errors since it's syntactically concise. …

So I've given `verror` a try, maybe there are strong arguments against it, so please comment your thoughts on this.

See https://github.com/sindresorhus/cpy/pull/9 for cpy output.