### PR TITLE
Update graceful-fs to ^4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "contents"
   ],
   "dependencies": {
-    "graceful-fs": "^3.0.2",
+    "graceful-fs": "^4.1.2",
     "mkdirp": "^0.5.0",
     "nested-error-stacks": "1.0.0",
     "object-assign": "^2.0.0",


### PR DESCRIPTION
This fixes issues with mock-fs (https://github.com/tschaub/mock-fs/issues/42).