### PR TITLE
Use native `chmod()` when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,12 @@ const checkSrcIsFile = (stat, src) => {
 };
 
 const fixupAttributes = (dest, stat) => {
-	fs.chmodSync(dest, stat.mode);
+	const version = process.version.substring(1).split('.').map(Number);
+
+	if (version[0] < 8 || (version[0] === 8 && version < 7)) {
+		fs.chmodSync(dest, stat.mode);
+	}
+
 	fs.chownSync(dest, stat.uid, stat.gid);
 };
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -284,6 +284,14 @@ test('rethrow EACCES errors of dest in fallback mode', t => {
 });
 
 test('rethrow chmod errors', t => {
+	const version = process.version.substring(1).split('.').map(Number);
+
+	// Only run test on node without native chmod()
+	if (version[0] > 8 || (version[0] === 8 && version[1] >= 7)) {
+		t.pass();
+		return;
+	}
+
 	const chmodError = buildEPERM(t.context.dest, 'chmod');
 
 	fs.chmodSync = sinon.stub(fs, 'chmodSync').throws(chmodError);


### PR DESCRIPTION
Fixes #22.