### PR TITLE
Incomplete solution to node v10 compatibility

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -8,22 +8,7 @@ const fsP = pify(fs);
 
 exports.closeSync = fs.closeSync.bind(fs);
 exports.createWriteStream = fs.createWriteStream.bind(fs);
-
-exports.createReadStream = (path, options) => new Promise((resolve, reject) => {
-	const read = fs.createReadStream(path, options);
-
-	read.on('error', err => {
-		reject(new CpFileError(`Cannot read from \`${path}\`: ${err.message}`, err));
-	});
-
-	read.on('readable', () => {
-		resolve(read);
-	});
-
-	read.on('end', () => {
-		resolve(read);
-	});
-});
+exports.createReadStream = fs.createReadStream.bind(fs);
 
 exports.stat = path => fsP.stat(path).catch(err => {
 	throw new CpFileError(`Cannot stat path \`${path}\`: ${err.message}`, err);

--- a/index.js
+++ b/index.js
@@ -20,10 +20,14 @@ module.exports = (src, dest, opts) => {
 		.then(stat => {
 			progressEmitter.size = stat.size;
 		})
-		.then(() => fs.createReadStream(src))
-		.then(read => fs.makeDir(path.dirname(dest)).then(() => read))
-		.then(read => new Promise((resolve, reject) => {
+		.then(() => fs.makeDir(path.dirname(dest)))
+		.then(() => new Promise((resolve, reject) => {
+			const read = fs.createReadStream(src);
 			const write = fs.createWriteStream(dest, {flags: opts.overwrite ? 'w' : 'wx'});
+
+			read.on('error', err => {
+				reject(new CpFileError(`Cannot read from \`${path}\`: ${err.message}`, err));
+			});
 
 			read.on('data', () => {
 				progressEmitter.written = write.bytesWritten;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"make-dir": "^1.0.0",
 		"nested-error-stacks": "^2.0.0",
 		"pify": "^3.0.0",
-		"safe-buffer": "^5.0.1"
+		"safe-buffer": "^5.1.2"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
This fails 3 tests in Node v10 - I can't quite find a way to keep cp-file's promise that it'll only create a directory for output if the output can be read from the stream - that requires waiting a tick between `readable` and `pipe` and that breaks behavior much more (instead of failing 3 tests, `master` fails 15.

Unfortunately the [Node v10 changelog only says](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md)

> The 'readable' event is now always deferred with nextTick.

Which doesn't clearly point to why this would break.