### PR TITLE
Require Node.js 8, detect read IO errors after open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - '10'
   - '8'
-  - '6'
 after_success:
   - './node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls'

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,9 +70,6 @@ declare const cpFile: {
 	@param destination - Where you want the file copied.
 	*/
 	sync(source: string, destination: string, options?: cpFile.Options): void;
-
-	// TODO: Remove this for the next major release
-	default: typeof cpFile;
 };
 
 export = cpFile;

--- a/index.js
+++ b/index.js
@@ -1,60 +1,58 @@
 'use strict';
 const path = require('path');
 const {constants: fsConstants} = require('fs');
-const {Buffer} = require('safe-buffer');
+const pEvent = require('p-event');
 const CpFileError = require('./cp-file-error');
 const fs = require('./fs');
 const ProgressEmitter = require('./progress-emitter');
+
+const cpFileAsync = async (source, destination, options, progressEmitter) => {
+	const stat = await fs.stat(source);
+	progressEmitter.size = stat.size;
+
+	const read = await fs.createReadStream(source);
+	await fs.makeDir(path.dirname(destination));
+	const write = fs.createWriteStream(destination, {flags: options.overwrite ? 'w' : 'wx'});
+	read.on('data', () => {
+		progressEmitter.written = write.bytesWritten;
+	});
+
+	let updateStats = false;
+	try {
+		const writePromise = pEvent(write, 'close');
+		read.pipe(write);
+		await writePromise;
+		progressEmitter.written = progressEmitter.size;
+		updateStats = true;
+	} catch (error) {
+		if (options.overwrite || error.code !== 'EEXIST') {
+			throw new CpFileError(`Cannot write to \`${destination}\`: ${error.message}`, error);
+		}
+	}
+
+	if (updateStats) {
+		const stats = await fs.lstat(source);
+
+		return Promise.all([
+			fs.utimes(destination, stats.atime, stats.mtime),
+			fs.chmod(destination, stats.mode),
+			fs.chown(destination, stats.uid, stats.gid)
+		]);
+	}
+};
 
 const cpFile = (source, destination, options) => {
 	if (!source || !destination) {
 		return Promise.reject(new CpFileError('`source` and `destination` required'));
 	}
 
-	options = Object.assign({overwrite: true}, options);
+	options = {
+		overwrite: true,
+		...options
+	};
 
 	const progressEmitter = new ProgressEmitter(path.resolve(source), path.resolve(destination));
-
-	const promise = fs
-		.stat(source)
-		.then(stat => {
-			progressEmitter.size = stat.size;
-		})
-		.then(() => fs.createReadStream(source))
-		.then(read => fs.makeDir(path.dirname(destination)).then(() => read))
-		.then(read => new Promise((resolve, reject) => {
-			const write = fs.createWriteStream(destination, {flags: options.overwrite ? 'w' : 'wx'});
-
-			read.on('data', () => {
-				progressEmitter.written = write.bytesWritten;
-			});
-
-			write.on('error', error => {
-				if (!options.overwrite && error.code === 'EEXIST') {
-					resolve(false);
-					return;
-				}
-
-				reject(new CpFileError(`Cannot write to \`${destination}\`: ${error.message}`, error));
-			});
-
-			write.on('close', () => {
-				progressEmitter.written = progressEmitter.size;
-				resolve(true);
-			});
-
-			read.pipe(write);
-		}))
-		.then(updateStats => {
-			if (updateStats) {
-				return fs.lstat(source).then(stats => Promise.all([
-					fs.utimes(destination, stats.atime, stats.mtime),
-					fs.chmod(destination, stats.mode),
-					fs.chown(destination, stats.uid, stats.gid)
-				]));
-			}
-		});
-
+	const promise = cpFileAsync(source, destination, options, progressEmitter);
 	promise.on = (...args) => {
 		progressEmitter.on(...args);
 		return promise;
@@ -64,8 +62,6 @@ const cpFile = (source, destination, options) => {
 };
 
 module.exports = cpFile;
-// TODO: Remove this for the next major release
-module.exports.default = cpFile;
 
 const checkSourceIsFile = (stat, source) => {
 	if (stat.isDirectory()) {
@@ -82,7 +78,16 @@ const fixupAttributes = (destination, stat) => {
 	fs.chownSync(destination, stat.uid, stat.gid);
 };
 
-const copySyncNative = (source, destination, options) => {
+module.exports.sync = (source, destination, options) => {
+	if (!source || !destination) {
+		throw new CpFileError('`source` and `destination` required');
+	}
+
+	options = {
+		overwrite: true,
+		...options
+	};
+
 	const stat = fs.statSync(source);
 	checkSourceIsFile(stat, source);
 	fs.makeDirSync(path.dirname(destination));
@@ -100,58 +105,4 @@ const copySyncNative = (source, destination, options) => {
 
 	fs.utimesSync(destination, stat.atime, stat.mtime);
 	fixupAttributes(destination, stat);
-};
-
-const copySyncFallback = (source, destination, options) => {
-	let bytesRead;
-	let position;
-	let read; // eslint-disable-line prefer-const
-	let write;
-	const BUF_LENGTH = 100 * 1024;
-	const buffer = Buffer.alloc(BUF_LENGTH);
-	const readSync = position => fs.readSync(read, buffer, 0, BUF_LENGTH, position, source);
-	const writeSync = () => fs.writeSync(write, buffer, 0, bytesRead, undefined, destination);
-
-	read = fs.openSync(source, 'r');
-	bytesRead = readSync(0);
-	position = bytesRead;
-	fs.makeDirSync(path.dirname(destination));
-
-	try {
-		write = fs.openSync(destination, options.overwrite ? 'w' : 'wx');
-	} catch (error) {
-		if (!options.overwrite && error.code === 'EEXIST') {
-			return;
-		}
-
-		throw error;
-	}
-
-	writeSync();
-
-	while (bytesRead === BUF_LENGTH) {
-		bytesRead = readSync(position);
-		writeSync();
-		position += bytesRead;
-	}
-
-	const stat = fs.fstatSync(read, source);
-	fs.futimesSync(write, stat.atime, stat.mtime, destination);
-	fs.closeSync(read);
-	fs.closeSync(write);
-	fixupAttributes(destination, stat);
-};
-
-module.exports.sync = (source, destination, options) => {
-	if (!source || !destination) {
-		throw new CpFileError('`source` and `destination` required');
-	}
-
-	options = Object.assign({overwrite: true}, options);
-
-	if (fs.copyFileSync) {
-		copySyncNative(source, destination, options);
-	} else {
-		copySyncFallback(source, destination, options);
-	}
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && nyc ava && tsd"
@@ -46,10 +46,9 @@
 	],
 	"dependencies": {
 		"graceful-fs": "^4.1.2",
-		"make-dir": "^2.0.0",
+		"make-dir": "^3.0.0",
 		"nested-error-stacks": "^2.0.0",
-		"pify": "^4.0.1",
-		"safe-buffer": "^5.0.1"
+		"p-event": "^4.1.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 ## Highlights
 
-- Fast by using streams in the async version and [`fs.copyFileSync()`](https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_flags) (when available) in the synchronous version.
+- Fast by using streams in the async version and [`fs.copyFileSync()`](https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_flags) in the synchronous version.
 - Resilient by using [graceful-fs](https://github.com/isaacs/node-graceful-fs).
 - User-friendly by creating non-existent destination directories for you.
 - Can be safe by turning off [overwriting](#optionsoverwrite).

--- a/test/async.js
+++ b/test/async.js
@@ -9,7 +9,7 @@ import uuid from 'uuid';
 import sinon from 'sinon';
 import cpFile from '..';
 import assertDateEqual from './helpers/assert';
-import {buildEACCES, buildENOSPC, buildENOENT, buildEPERM} from './helpers/fs-errors';
+import {buildEACCES, buildEIO, buildENOSPC, buildENOENT, buildEPERM} from './helpers/fs-errors';
 
 const THREE_HUNDRED_KILO = (100 * 3 * 1024) + 1;
 
@@ -169,6 +169,8 @@ test.serial('rethrow ENOSPC errors', async t => {
 	t.is(error.errno, noSpaceError.errno, error);
 	t.is(error.code, noSpaceError.code, error);
 	t.true(called);
+
+	fs.createWriteStream = createWriteStream;
 });
 
 test.serial('rethrow stat errors', async t => {
@@ -233,4 +235,45 @@ test.serial('rethrow chown errors', async t => {
 	t.true(fs.chown.called);
 
 	fs.chown.restore();
+});
+
+test.serial('rethrow read after open errors', async t => {
+	const {createWriteStream, createReadStream} = fs;
+	let calledWriteEnd = 0;
+	let readStream;
+	const readError = buildEIO();
+
+	fs.createWriteStream = (...args) => {
+		const stream = createWriteStream(...args);
+		const {end} = stream;
+
+		stream.on('pipe', () => {
+			readStream.emit('error', readError);
+		});
+
+		stream.end = (...endArgs) => {
+			calledWriteEnd++;
+			return end.apply(stream, endArgs);
+		};
+
+		return stream;
+	};
+
+	fs.createReadStream = (...args) => {
+		/* Fake stream */
+		readStream = createReadStream(...args);
+		readStream.pause();
+
+		return readStream;
+	};
+
+	clearModule('../fs');
+	const uncached = importFresh('..');
+	const error = await t.throwsAsync(uncached('license', t.context.destination));
+	t.is(error.name, 'CpFileError', error);
+	t.is(error.errno, readError.errno, error);
+	t.is(error.code, readError.code, error);
+	t.is(calledWriteEnd, 1);
+
+	Object.assign(fs, {createWriteStream, createReadStream});
 });

--- a/test/helpers/fs-errors.js
+++ b/test/helpers/fs-errors.js
@@ -17,6 +17,11 @@ exports.buildENOENT = path => Object.assign(new Error(`ENOENT: no such file or d
 	path
 });
 
+exports.buildEIO = () => Object.assign(new Error('EIO: i/o error, read errno: -5'), {
+	errno: -5,
+	code: 'EIO'
+});
+
 exports.buildEBADF = () => Object.assign(new Error('EBADF: bad file descriptor'), {
 	errno: -9,
 	code: 'EBADF'

--- a/test/sync.js
+++ b/test/sync.js
@@ -161,36 +161,7 @@ test('rethrow mkdir EACCES errors', t => {
 	fs.mkdirSync.restore();
 });
 
-test('rethrow ENOSPC errors in fallback mode', t => {
-	// Only run test on node without native fs.copyFileSync
-	if (fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
-	const noSpaceError = buildENOSPC();
-
-	fs.writeFileSync(t.context.source, '');
-	fs.writeSync = sinon.stub(fs, 'writeSync').throws(noSpaceError);
-
-	const error = t.throws(() => {
-		cpFile.sync('license', t.context.destination);
-	});
-	t.is(error.name, 'CpFileError', error);
-	t.is(error.errno, noSpaceError.errno, error);
-	t.is(error.code, noSpaceError.code, error);
-	t.true(fs.writeSync.called);
-
-	fs.writeSync.restore();
-});
-
-test('rethrow ENOSPC errors in native mode', t => {
-	// Only run test on node with native fs.copyFileSync
-	if (!fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
+test('rethrow ENOSPC errors', t => {
 	const noSpaceError = buildENOSPC();
 
 	fs.writeFileSync(t.context.source, '');
@@ -207,36 +178,7 @@ test('rethrow ENOSPC errors in native mode', t => {
 	fs.copyFileSync.restore();
 });
 
-test('rethrow fstat errors', t => {
-	// Only run test on node without native fs.copyFileSync
-	if (fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
-	const fstatError = buildEBADF();
-
-	fs.writeFileSync(t.context.source, '');
-	fs.fstatSync = sinon.stub(fs, 'fstatSync').throws(fstatError);
-
-	const error = t.throws(() => {
-		cpFile.sync(t.context.source, t.context.destination);
-	});
-	t.is(error.name, 'CpFileError', error);
-	t.is(error.errno, fstatError.errno, error);
-	t.is(error.code, fstatError.code, error);
-	t.true(fs.fstatSync.called);
-
-	fs.fstatSync.restore();
-});
-
 test('rethrow stat errors', t => {
-	// Only run test on node with native fs.copyFileSync
-	if (!fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
 	const statError = buildEBADF();
 
 	fs.writeFileSync(t.context.source, '');
@@ -254,35 +196,7 @@ test('rethrow stat errors', t => {
 	fs.statSync.restore();
 });
 
-test('rethrow utimes errors in fallback mode', t => {
-	// Only run test on node without native fs.copyFileSync
-	if (fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
-	const futimesError = buildEBADF();
-
-	fs.futimesSync = sinon.stub(fs, 'futimesSync').throws(futimesError);
-
-	const error = t.throws(() => {
-		cpFile.sync('license', t.context.destination);
-	});
-	t.is(error.name, 'CpFileError', error);
-	t.is(error.errno, futimesError.errno, error);
-	t.is(error.code, futimesError.code, error);
-	t.true(fs.futimesSync.called);
-
-	fs.futimesSync.restore();
-});
-
-test('rethrow utimes errors in native mode', t => {
-	// Only run test on node with native fs.copyFileSync
-	if (!fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
+test('rethrow utimes errors', t => {
 	const futimesError = buildEBADF();
 
 	fs.utimesSync = sinon.stub(fs, 'utimesSync').throws(futimesError);
@@ -296,29 +210,6 @@ test('rethrow utimes errors in native mode', t => {
 	t.true(fs.utimesSync.called);
 
 	fs.utimesSync.restore();
-});
-
-test('rethrow EACCES errors of dest in fallback mode', t => {
-	// Only run test on node without native fs.copyFileSync
-	if (fs.copyFileSync) {
-		t.pass();
-		return;
-	}
-
-	const openError = buildEACCES(t.context.destination);
-
-	fs.openSync = sinon.stub(fs, 'openSync').throws(openError);
-
-	const error = t.throws(() => {
-		cpFile.sync('license', t.context.destination);
-	});
-	t.is(error.name, 'CpFileError', error);
-	t.is(error.errno, openError.errno, error);
-	t.is(error.code, openError.code, error);
-	t.is(error.path, openError.path, error);
-	t.true(fs.openSync.called);
-
-	fs.openSync.restore();
 });
 
 test('rethrow chmod errors', t => {


### PR DESCRIPTION
@sindresorhus if you prefer I can drop the second commit from this PR, resubmit separately if/when the first is merged.  First commit upgrades everything to the node.js 8 way (technically this requires node.js 8.5 for fs.copyFileSync).

Second commit addresses the existing issue where read IO errors after open were not processed.  In addition to the automated test I manually tested by unplugging a USB drive in the middle of copying a Linux distro ISO from it (that's where I got the exact EIO error used in testing).  If you don't want the first commit then @Henry128 can probably just copy my test into #31.

Fixes #30
Closes #31