### PR TITLE
Add `directoryMode` option

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -57,13 +57,13 @@ exports.utimesSync = (path, atime, mtime) => {
 	}
 };
 
-exports.makeDir = path => makeDir(path, {fs}).catch(error => {
+exports.makeDir = (path, options) => makeDir(path, {...options, fs}).catch(error => {
 	throw new CpFileError(`Cannot create directory \`${path}\`: ${error.message}`, error);
 });
 
-exports.makeDirSync = path => {
+exports.makeDirSync = (path, options) => {
 	try {
-		makeDir.sync(path, {fs});
+		makeDir.sync(path, {...options, fs});
 	} catch (error) {
 		throw new CpFileError(`Cannot create directory \`${path}\`: ${error.message}`, error);
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace cpFile {
 
 		@default 0o777
 		*/
-		readonly directoryMode?: number | string;
+		readonly directoryMode?: number;
 	}
 
 	interface ProgressData {

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,13 @@ declare namespace cpFile {
 		@default true
 		*/
 		readonly overwrite?: boolean;
+
+		/**
+		Permissions for created directories.
+
+		@default 0o777
+		*/
+		readonly directoryMode?: number | string;
 	}
 
 	interface ProgressData {

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace cpFile {
 		readonly overwrite?: boolean;
 
 		/**
-		Permissions for created directories.
+		[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
 
 		@default 0o777
 		*/

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const cpFileAsync = async (source, destination, options, progressEmitter) => {
 	progressEmitter.size = stat.size;
 
 	const readStream = await fs.createReadStream(source);
-	await fs.makeDir(path.dirname(destination));
+	await fs.makeDir(path.dirname(destination), {mode: options.directoryMode});
 	const writeStream = fs.createWriteStream(destination, {flags: options.overwrite ? 'w' : 'wx'});
 
 	readStream.on('data', () => {
@@ -94,7 +94,7 @@ module.exports.sync = (source, destination, options) => {
 
 	const stat = fs.statSync(source);
 	checkSourceIsFile(stat, source);
-	fs.makeDirSync(path.dirname(destination));
+	fs.makeDirSync(path.dirname(destination), {mode: options.directoryMode});
 
 	const flags = options.overwrite ? null : fsConstants.COPYFILE_EXCL;
 	try {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,6 +8,16 @@ expectType<Promise<void> & ProgressEmitter>(
 expectType<Promise<void> & ProgressEmitter>(
 	cpFile('source/unicorn.png', 'destination/unicorn.png', {overwrite: false})
 );
+expectType<Promise<void> & ProgressEmitter>(
+	cpFile('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: 0o700
+	})
+);
+expectType<Promise<void> & ProgressEmitter>(
+	cpFile('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: '700'
+	})
+);
 expectType<Promise<void>>(
 	cpFile('source/unicorn.png', 'destination/unicorn.png').on(
 		'progress',
@@ -27,5 +37,15 @@ expectType<void>(cpFile.sync('source/unicorn.png', 'destination/unicorn.png'));
 expectType<void>(
 	cpFile.sync('source/unicorn.png', 'destination/unicorn.png', {
 		overwrite: false
+	})
+);
+expectType<void>(
+	cpFile.sync('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: 0o700
+	})
+);
+expectType<void>(
+	cpFile.sync('source/unicorn.png', 'destination/unicorn.png', {
+		directoryMode: '700'
 	})
 );

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd';
+import {expectError, expectType} from 'tsd';
 import cpFile = require('.');
 import {ProgressEmitter, ProgressData} from '.';
 
@@ -13,8 +13,8 @@ expectType<Promise<void> & ProgressEmitter>(
 		directoryMode: 0o700
 	})
 );
-expectType<Promise<void> & ProgressEmitter>(
-	cpFile('source/unicorn.png', 'destination/unicorn.png', {
+expectError(
+	await cpFile('source/unicorn.png', 'destination/unicorn.png', {
 		directoryMode: '700'
 	})
 );
@@ -44,7 +44,7 @@ expectType<void>(
 		directoryMode: 0o700
 	})
 );
-expectType<void>(
+expectError(
 	cpFile.sync('source/unicorn.png', 'destination/unicorn.png', {
 		directoryMode: '700'
 	})

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Overwrite existing destination file.
 
 ##### directoryMode
 
-Type: `number` | `string`\
+Type: `number`\
 Default: `0o777`
 
 Permissions for created directories.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Overwrite existing destination file.
 Type: `number`\
 Default: `0o777`
 
-Permissions for created directories.
+[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
 
 ### cpFile.on('progress', handler)
 

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Overwrite existing destination file.
 Type: `number`\
 Default: `0o777`
 
-[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories.
+[Permissions](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation) for created directories. Not supported on Windows.
 
 ### cpFile.on('progress', handler)
 

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,13 @@ Default: `true`
 
 Overwrite existing destination file.
 
+##### directoryMode
+
+Type: `number` | `string`\
+Default: `0o777`
+
+Permissions for created directories.
+
 ### cpFile.on('progress', handler)
 
 Progress reporting. Only available when using the async method.

--- a/test/async.js
+++ b/test/async.js
@@ -80,6 +80,15 @@ test('do not overwrite when disabled', async t => {
 	t.is(error.code, 'EEXIST', error.message);
 });
 
+test('create directories with specified mode', async t => {
+	const directory = t.context.destination;
+	const destination = `${directory}/${uuidv4()}`;
+	const directoryMode = 0o700;
+	await cpFile('license', destination, {directoryMode});
+	const stat = fs.statSync(directory);
+	t.is(stat.mode & directoryMode, directoryMode);
+});
+
 test('do not create `destination` on unreadable `source`', async t => {
 	const error = await t.throwsAsync(cpFile('node_modules', t.context.destination));
 	t.is(error.name, 'CpFileError', error.message);

--- a/test/sync.js
+++ b/test/sync.js
@@ -81,6 +81,15 @@ test('do not overwrite when disabled', t => {
 	t.is(fs.readFileSync(t.context.destination, 'utf8'), '');
 });
 
+test('create directories with specified mode', t => {
+	const directory = t.context.destination;
+	const destination = `${directory}/${uuidv4()}`;
+	const directoryMode = 0o700;
+	cpFile.sync('license', destination, {directoryMode});
+	const stat = fs.statSync(directory);
+	t.is(stat.mode & directoryMode, directoryMode);
+});
+
 test('do not create `destination` on unreadable `source`', t => {
 	t.throws(
 		() => {


### PR DESCRIPTION
Adds an option `directoryMode` which enables controlling permissions of implicitly created directories.